### PR TITLE
Changed deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          cname: www.muttermixs.com


### PR DESCRIPTION
This pull request introduces a minor configuration update to the deployment workflow. The change ensures that the deployed site is assigned a custom domain.

* Deployment configuration:
  * [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R35): Added the `cname` parameter with value `www.muttermixs.com` to the deployment job, enabling the use of a custom domain for the published site.