### PR TITLE
Changed to not use www.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
-          cname: www.muttermixs.com
+          cname: muttermixs.com


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration. The custom domain used for publishing the site has been changed from `www.muttermixs.com` to `muttermixs.com`.